### PR TITLE
fixed get all actions in wait_for_new_message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include-package-data = true
 
 [project]
 name = "protonmail-api-client"
-version = "1.6.0"
+version = "1.6.1"
 description = "This is not an official python ProtonMail API client. it allows you to read, send and delete messages in protonmail, as well as render a ready-made template with embedded images."
 readme = "README.md"
 authors = [{ name = "opulentfox-29", email = "3acqw2bx@duck.com" }]

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -386,9 +386,11 @@ class ProtonMail:
         :raises TimeoutError: at the end of the `timeout` only if the `rise_timeout` is `True`
         """
         def func(response: dict):
-            messages = response.get('Messages')
-            if messages:
-                new_message = self._convert_dict_to_message(messages[0]['Message'])
+            messages = response.get('Messages', [])
+            for message in messages:
+                if message.get('Action') != 1:  # new message
+                    continue
+                new_message = self._convert_dict_to_message(message['Message'])
                 return new_message
             return None
         message = self.event_polling(


### PR DESCRIPTION
The `wait_for new_message` function could consider any event (for example, reading a message) as receiving a new message

fixed #22