### PR TITLE
Working with labels and add method `is_draft` to message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include-package-data = true
 
 [project]
 name = "protonmail-api-client"
-version = "1.6.1"
+version = "1.7.0"
 description = "This is not an official python ProtonMail API client. it allows you to read, send and delete messages in protonmail, as well as render a ready-made template with embedded images."
 readme = "README.md"
 authors = [{ name = "opulentfox-29", email = "3acqw2bx@duck.com" }]

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -26,8 +26,8 @@ from aiohttp import ClientSession, TCPConnector
 from requests_toolbelt import MultipartEncoder
 from tqdm.asyncio import tqdm_asyncio
 
-from .exceptions import SendMessageError, InvalidTwoFactorCode, LoadSessionError, AddressNotFound, CantUploadAttachment
-from .models import Attachment, Message, UserMail, Conversation, PgpPairKeys
+from .exceptions import SendMessageError, InvalidTwoFactorCode, LoadSessionError, AddressNotFound, CantUploadAttachment, CantSetLabel, CantUnsetLabel, CantGetLabels
+from .models import Attachment, Message, UserMail, Conversation, PgpPairKeys, Label
 from .constants import DEFAULT_HEADERS, urls_api
 from .utils.pysrp import User
 from .logger import Logger
@@ -463,6 +463,123 @@ class ProtonMail:
             time.sleep(need_sleep)
         if rise_timeout:
             raise TimeoutError
+        return None
+
+    def get_labels_by_type_id(self, type_id: int) -> list[Label]:
+        """
+        Get labels by type id
+
+        :param type_id: type of labels (folders, labels, etc.)
+                        possible types:
+                            1 - User's custom labels.
+                            2 - Actually, I have no idea what it is. If this returned a non-empty list for you, please let me know what it is
+                            3 - User's custom folders
+                            4 - ProtonMail's system labels (inbox, drafts, sent, spam, etc.)
+        :returns: list of labels
+        """
+        params = {
+            'Type': type_id,
+        }
+        response = self._get('mail', 'core/v4/labels', params=params).json()
+        if response['Code'] not in [1000, 1001]:
+            raise CantGetLabels(response['Error'])
+        type_mapper = {
+            1: 'user label',
+            2: 'undefined',
+            3: 'user folder',
+            4: 'system folder',
+        }
+        labels = [
+            Label(
+                id=label['ID'],
+                name=label['Name'],
+                path=label['Path'],
+                type=label['Type'],
+                type_name=type_mapper[label['Type']],
+                color=label['Color'],
+                notify=label['Notify'],
+                display=label['Display'],
+                parent_id=label.get('ParentID'),
+            )
+            for label in response['Labels']
+        ]
+
+        return labels
+
+    def get_all_labels(self) -> list[Label]:
+        """Get all labels."""
+        labels = []
+        labels1 = self.get_user_folders()
+        labels2 = self.get_labels_by_type_id(2)
+        labels3 = self.get_user_labels()
+        labels4 = self.get_system_labels()
+        labels.extend(labels1)
+        labels.extend(labels2)
+        labels.extend(labels3)
+        labels.extend(labels4)
+        return labels
+
+    def get_system_labels(self) -> list[Label]:
+        """Get ProtonMail's system labels."""
+        labels = self.get_labels_by_type_id(4)
+        return labels
+
+    def get_user_labels(self) -> list[Label]:
+        """Get user's labels."""
+        labels = self.get_labels_by_type_id(3)
+        return labels
+
+    def get_user_folders(self) -> list[Label]:
+        """Get user's folders."""
+        labels = self.get_labels_by_type_id(1)
+        return labels
+
+    def set_label_for_messages(self, label_or_id: Union[Label, str], messages_or_ids: list[Message, str]) -> None:
+        """
+        Set label for messages.
+
+        :param label_or_id: label or label id
+        :param messages_or_ids: list of messages or message IDs.
+        """
+        message_ids = [message.id if isinstance(message, Message) else message for message in messages_or_ids]
+        payload = {
+            'LabelID': label_or_id.id if isinstance(label_or_id, Label) else label_or_id,
+            'IDs': message_ids,
+        }
+        response = self._put('mail', 'mail/v4/messages/label', json=payload).json()
+        if response['Code'] not in [1000, 1001]:
+            raise CantSetLabel(response['Error'])
+        errors = []
+        for resp in response['Responses']:
+            if resp['Response']['Code'] in [1000, 1001]:
+                continue
+            errors.append({'id': resp['ID'], 'code': resp['Response']['Code'], 'error': resp['Response']['Error']})
+        if errors:
+            raise CantSetLabel(errors)
+        return None
+
+    def unset_label_for_messages(self, label_or_id: Union[Label, str], messages_or_ids: list[Message, str]) -> None:
+        """
+        Unset label for messages.
+
+        :param label_or_id: label or label id
+        :param messages_or_ids: list of messages or message IDs.
+        """
+        message_ids = [message.id if isinstance(message, Message) else message for message in messages_or_ids]
+        payload = {
+            'LabelID': label_or_id.id if isinstance(label_or_id, Label) else label_or_id,
+            'IDs': message_ids,
+        }
+        response = self._put('mail', 'mail/v4/messages/unlabel', json=payload).json()
+        if response['Code'] not in [1000, 1001]:
+            raise CantUnsetLabel(response['Error'])
+        errors = []
+        for resp in response['Responses']:
+            if resp['Response']['Code'] in [1000, 1001]:
+                continue
+            errors.append({'id': resp['ID'], 'code': resp['Response']['Code'], 'error': resp['Response']['Error']})
+        if errors:
+            raise CantSetLabel(errors)
         return None
 
     def pgp_import(self, private_key: str, passphrase: str) -> None:

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -133,16 +133,17 @@ class ProtonMail:
 
         return message
 
-    def get_messages(self, page_size: Optional[int] = 150) -> list[Message]:
+    def get_messages(self, page_size: Optional[int] = 150, label_or_id: Union[Label, str] = '5') -> list[Message]:
         """
         Get all messages, sorted by time.
 
         :param page_size: number of posts per page. maximum number 150.
-        :type page_size: ``int``
+        :param label_or_id: get messages by label. default: 5 (All Mail)
         :returns: :py:obj:`list[Message]`
         """
+        label_id = label_or_id.id if isinstance(label_or_id, Label) else label_or_id
         count_page = ceil(self.get_messages_count()[5]['Total'] / page_size)
-        args_list = [(page_num, page_size) for page_num in range(count_page)]
+        args_list = [(page_num, page_size, label_id) for page_num in range(count_page)]
         messages_lists = self._async_helper(self._async_get_messages, args_list)
         messages_dict = self._flattening_lists(messages_lists)
         messages = [self._convert_dict_to_message(message) for message in messages_dict]
@@ -1042,13 +1043,14 @@ class ProtonMail:
             self,
             client: ClientSession,
             page: int,
-            page_size: Optional[int] = 150
+            page_size: Optional[int] = 150,
+            label_id: str = '5',
     ) -> list:
         params = {
             "Page": page,
             "PageSize": page_size,
             "Limit": page_size,
-            "LabelID": "5",
+            "LabelID": label_id,
             "Sort": "Time",
             "Desc": "1",
         }

--- a/src/protonmail/exceptions.py
+++ b/src/protonmail/exceptions.py
@@ -27,3 +27,13 @@ class AddressNotFound(Exception):
 
 class CantUploadAttachment(Exception):
     """Error when try to upload attachment"""
+
+
+class CantGetLabels(Exception):
+    """Error when try to get labels"""
+
+class CantSetLabel(Exception):
+    """Error when try to set label for a message"""
+
+class CantUnsetLabel(Exception):
+    """Error when try to unset label for a message"""

--- a/src/protonmail/models.py
+++ b/src/protonmail/models.py
@@ -63,6 +63,31 @@ class Attachment:
 
 
 @dataclass
+class Label:
+    """Label."""
+    id: str
+    name: str
+    path: Optional[str]
+    type: int
+    type_name: str
+    color: str
+    notify: bool
+    display: bool
+    parent_id: Optional[str] = None
+
+    def __str__(self):
+        return f"<Label [{self.id}, name: {self.name}, type: {self.type}]>"
+
+    def to_dict(self) -> dict[str, any]:
+        """
+        Object to dict
+
+        :returns: :py:obj:`dict`
+        """
+        return asdict(self)
+
+
+@dataclass
 class Message:
     """Message."""
     id: str = ''
@@ -75,7 +100,7 @@ class Message:
     size: int = 0
     body: str = ''
     type: str = ''
-    labels: list[str] = field(default_factory=list)
+    labels: list[str, Label] = field(default_factory=list)
     attachments: list[Attachment] = field(default_factory=list)
     extra: dict = field(default_factory=dict)
 
@@ -91,6 +116,23 @@ class Message:
         :returns: :py:obj:`dict`
         """
         return asdict(self)
+
+    def is_draft(self) -> bool:
+        """This message is draft or not"""
+        labels_ids = set(label.id if isinstance(label, Label) else label for label in self.labels)
+        if {'1', '8'} & labels_ids:
+            return True
+        return False
+
+    def convert_labels(self, labels: list[Label]):
+        """
+        Replace label_id with label obj. If there is no corresponding label, the label_id will remain.
+
+        :param labels: list of labels
+        """
+        labels_mapper = {label.id: label for label in labels}
+        self.labels = [labels_mapper[label_id] if label_id in labels_mapper else label_id for label_id in self.labels]
+
 
 
 @dataclass


### PR DESCRIPTION
- added working with labels
- added method `is_draft` to message

# working wtih labels
Now you can get labels by type id:
```python
labels = proton.get_labels_by_type_id(label_id)
```
Possible types:
- 1 - User's custom labels.
- 2 - Actually, I have no idea what it is. If this returned a non-empty list for you, please let me know what it is.
- 3 - User's custom folders.
-  4 - ProtonMail's system labels/folders (inbox, drafts, sent, spam, etc.)

Or you can get labels in another way:
```python
user_folders = proton.get_user_folders()
user_labels = proton.get_user_labels()
system_labels = proton.get_system_labels()
```
Or you can get all labels:
```python
labels = proton.get_all_labels()
```
Convert label_ids to label_obj in message:
```python
print(message.labels)  # ['1', '5', '8', '15']
message.convert_labels(labels)
print(message.labels)  # [Label(id='8', name='Drafts', ...), ...]
```

Set/Unset label for messages:
```python
proton.set_label_for_messages(label_or_id=label, messages_or_ids=[message])
proton.unset_label_for_messages(label_or_id=label, messages_or_ids=[message])
```

Get messages by label:
```python
messages = proton.get_messages(label_or_id='4')  # spam
```

# Message is_draft method
```python
message.is_draft()
```