### PR TITLE
Fix `TypeError: 'staticmethod' object is not callable` in python 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include-package-data = true
 
 [project]
 name = "protonmail-api-client"
-version = "1.7.0"
+version = "1.7.1"
 description = "This is not an official python ProtonMail API client. it allows you to read, send and delete messages in protonmail, as well as render a ready-made template with embedded images."
 readme = "README.md"
 authors = [{ name = "opulentfox-29", email = "3acqw2bx@duck.com" }]


### PR DESCRIPTION
There is a bug in python 3.9 where a wrapper can't be a staticmethod of a class, so i moved it to another file.

fixed #27