### PR TITLE
Added wheel in build and update build configs

### DIFF
--- a/manifest.in
+++ b/manifest.in
@@ -1,2 +1,0 @@
-recursive-include src/protonmail *
-prune **/__pycache__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,21 @@
 [build-system]
-requires      = ["setuptools>=61.0.0", "wheel"]
+requires = ["setuptools>=63.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
-
-[tool.setuptools]
-include-package-data = true
 
 [project]
 name = "protonmail-api-client"
-version = "1.7.1"
+version = "1.7.2"
 description = "This is not an official python ProtonMail API client. it allows you to read, send and delete messages in protonmail, as well as render a ready-made template with embedded images."
 readme = "README.md"
 authors = [{ name = "opulentfox-29", email = "3acqw2bx@duck.com" }]
 license = { file = "LICENSE" }
 keywords = ["protonmail", "api", "client", "proton", "proton-mail", "send", "read", "mail", "email", "python", "python3"]
-dependencies = [
-	"aiohttp",
-	"bcrypt",
-	"PGPy",
-	"pycryptodome",
-	"requests",
-	"requests-toolbelt",
-	"typing_extensions",
-	"tqdm"
-]
 requires-python = ">=3.9"
+dynamic = ["dependencies", "optional-dependencies"]
 
-[project.optional-dependencies]
-dev = ["twine", "build"]
+[tool.setuptools.dynamic]
+dependencies = {file = ["requirements.txt"]}
+optional-dependencies = {dev = { file = ["requirements-dev.txt"] }}
 
 [project.urls]
 Homepage = "https://github.com/opulentfox-29/protonmail-api-client"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+setuptools>=63.0.0
+build
+twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[egg_info]
-tag_build = 
-tag_date = 0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup
-
-setup()


### PR DESCRIPTION
- removed build by sdist+setup.py
- update pyproject.toml structure
- include wheel in build (on Linux with `pip<23` this project could not be installed and the project version was automatically downgraded to `1.3.4`, which had wheel in the build, this happened, for example, on default Ubuntu 22.04)

Fixed #21
Fixed #26