### PR TITLE
Added methods for mark messages/conversations as read/unread

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "protonmail-api-client"
-version = "1.7.2"
+version = "1.8.0"
 description = "This is not an official python ProtonMail API client. it allows you to read, send and delete messages in protonmail, as well as render a ready-made template with embedded images."
 readme = "README.md"
 authors = [{ name = "opulentfox-29", email = "3acqw2bx@duck.com" }]

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -360,6 +360,45 @@ class ProtonMail:
         }
         self._put('mail', 'mail/v4/messages/read', json=data)
 
+    def mark_messages_as_unread(self, messages_or_ids: list[Union[Message, str]]) -> None:
+        """
+        Mark as unread messages.
+
+        :param messages_or_ids: list of messages or messages id.
+        :type messages_or_ids: :py:obj:`Message`
+        """
+        ids = [i.id if isinstance(i, Message) else i for i in messages_or_ids]
+        data = {
+            'IDs': ids,
+        }
+        self._put('mail', 'mail/v4/messages/unread', json=data)
+
+    def mark_conversations_as_read(self, conversations_or_ids: list[Union[Conversation, str]]) -> None:
+        """
+        Mark as read conversations.
+
+        :param conversations_or_ids: list of conversations or conversations id.
+        :type conversations_or_ids: :py:obj:`Conversation`
+        """
+        ids = [i.id if isinstance(i, Conversation) else i for i in conversations_or_ids]
+        data = {
+            'IDs': ids,
+        }
+        self._put('mail', 'mail/v4/conversations/read', json=data)
+
+    def mark_conversations_as_unread(self, conversations_or_ids: list[Union[Conversation, str]]) -> None:
+        """
+        Mark as unread conversations.
+
+        :param conversations_or_ids: list of conversations or conversations id.
+        :type conversations_or_ids: :py:obj:`Conversation`
+        """
+        ids = [i.id if isinstance(i, Conversation) else i for i in conversations_or_ids]
+        data = {
+            'IDs': ids,
+        }
+        self._put('mail', 'mail/v4/conversations/unread', json=data)
+
     def wait_for_new_message(
             self,
             *args,


### PR DESCRIPTION
Now you can mark your messages/conversation as read/unread
(method for mark messages as read was added before)
## Messages
```python
messages = proton.get_messages()
proton.mark_messages_as_unread(messages)
proton.mark_messages_as_read(messages)
```
## Conversations
```python
conversations = proton.get_conversations()
proton.mark_conversations_as_unread(conversations)
proton.mark_conversations_as_read(conversations)
```