### PR TITLE
Call is_draft on message class, not dict

### DIFF
--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -438,7 +438,7 @@ class ProtonMail:
                 if message.get('Action') != 1:  # new message
                     continue
                 new_message = self._convert_dict_to_message(message['Message'])
-                if message.is_draft():  # skip saving draft
+                if new_message.is_draft():  # skip saving draft
                     continue
                 return new_message
             return None


### PR DESCRIPTION
The fix to #39 appears to have broken wait_for_new_message, since it creates an AttributeError by trying to call is_draft on the message dict and not the Message object:

```
File "venv/lib/python3.13/site-packages/protonmail/client.py", line 441, in func
    if message.is_draft():  # skip saving draft
       ^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'is_draft'
```

This fixes that