### PR TITLE
Fixed error in accounts with old RSA keys

### DIFF
--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -1023,6 +1023,12 @@ class ProtonMail:
 
         for account_address in account_addresses:
             for address_key in account_address['Keys']:
+                if address_key['Token'] is None:  # Old (older than ~2020) keys is RSA, don't work
+                    self.logger.warning(
+                        f"Encryption Key ({address_key['Fingerprint']}) is invalid (maybe old RSA), will be skipped (you can't read messages by this key)",
+                        "yellow",
+                    )
+                    continue
                 address_passphrase = self.pgp.decrypt(address_key['Token'], user_pair_key['PrivateKey'], user_private_key_password)
 
                 self.pgp.pairs_keys.append(PgpPairKeys(


### PR DESCRIPTION
Fixed error in accounts with old RSA keys, just skip them.