### PR TITLE
Enable setting the External Id and add Cc, Bcc and In-Reply-To support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ new_message = proton.create_message(
     body=html,  # html or just text
     attachments=[img_attachment, pdf_attachment],
     external_id="some-message-id-header-if-you-want-to-specify",
+    in_reply_to="message-id-of-the-mail-to-reply-to",
 )
 
 sent_message = proton.send_message(new_message)

--- a/README.md
+++ b/README.md
@@ -63,9 +63,12 @@ html = f"""
 # Send message
 new_message = proton.create_message(
     recipients=["to1@proton.me", "to2@gmail.com"],
+    cc=["cc1@proton.me", "cc2@gmail.com"],
+    bcc=["bcc1@proton.me", "bcc2@gmail.com"],
     subject="My first message",
     body=html,  # html or just text
     attachments=[img_attachment, pdf_attachment],
+    external_id="some-message-id-header-if-you-want-to-specify",
 )
 
 sent_message = proton.send_message(new_message)

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -370,6 +370,7 @@ class ProtonMail:
                 'AddressID': account_address.id,
                 'Unread': 0,
                 'Body': pgp_body,
+                'ExternalID': message.external_id,
             },
         }
         for recipient in message.recipients:

--- a/src/protonmail/client.py
+++ b/src/protonmail/client.py
@@ -368,6 +368,11 @@ class ProtonMail:
             account_address = self.account_addresses[0]
         pgp_body = self.pgp.encrypt(message.body)
 
+        # Sanitize external_id if present
+        external_id = message.external_id
+        if external_id and external_id.startswith('<') and external_id.endswith('>'):
+            external_id = external_id[1:-1]
+
         data = {
             'Message': {
                 'ToList': [],
@@ -384,7 +389,7 @@ class ProtonMail:
                 'AddressID': account_address.id,
                 'Unread': 0,
                 'Body': pgp_body,
-                'ExternalID': message.external_id,
+                'ExternalID': external_id,
             },
         }
         for recipient in message.recipients:

--- a/src/protonmail/models.py
+++ b/src/protonmail/models.py
@@ -152,6 +152,7 @@ class Message:
     unread: bool = False
     sender: UserMail = field(default_factory=UserMail)
     recipients: list[UserMail] = field(default_factory=list)
+    cc: list[UserMail] = field(default_factory=list)
     time: int = 0
     size: int = 0
     body: str = ''

--- a/src/protonmail/models.py
+++ b/src/protonmail/models.py
@@ -161,6 +161,7 @@ class Message:
     labels: list[str, Label] = field(default_factory=list)
     attachments: list[Attachment] = field(default_factory=list)
     external_id: str = ''
+    in_reply_to: str = ''
     extra: dict = field(default_factory=dict)
 
     def __str__(self):

--- a/src/protonmail/models.py
+++ b/src/protonmail/models.py
@@ -153,6 +153,7 @@ class Message:
     sender: UserMail = field(default_factory=UserMail)
     recipients: list[UserMail] = field(default_factory=list)
     cc: list[UserMail] = field(default_factory=list)
+    bcc: list[UserMail] = field(default_factory=list)
     time: int = 0
     size: int = 0
     body: str = ''

--- a/src/protonmail/models.py
+++ b/src/protonmail/models.py
@@ -158,6 +158,7 @@ class Message:
     type: str = ''
     labels: list[str, Label] = field(default_factory=list)
     attachments: list[Attachment] = field(default_factory=list)
+    external_id: str = ''
     extra: dict = field(default_factory=dict)
 
     def __str__(self):


### PR DESCRIPTION
Sometimes mbox emails specify a Message-ID header. Its value is send as the ExternalId to the ProtonMail API.